### PR TITLE
Fix duration parser and add tests

### DIFF
--- a/hcctl/src/main.rs
+++ b/hcctl/src/main.rs
@@ -156,3 +156,25 @@ fn human_readable_duration(now: &DateTime<Utc>, date_str: &str) -> Result<String
     ))
 }
 
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+
+    use super::*;
+
+    #[test]
+    fn duration_parses_correctly() {
+        let now = &Utc.ymd(2021, 1, 26).and_hms(19, 38, 0);
+        let duration =
+            human_readable_duration(now, &"2021-01-26T14:00:24+00:00".to_owned()).unwrap();
+        assert!(duration == "5 hour(s) and 2 minute(s) ago")
+    }
+
+    #[test]
+    fn duration_parses_correctly_with_only_minutes() {
+        let now = &Utc.ymd(2021, 1, 26).and_hms(14, 38, 0);
+        let duration =
+            human_readable_duration(now, &"2021-01-26T14:00:24+00:00".to_owned()).unwrap();
+        assert!(duration == "0 hour(s) and 37 minute(s) ago")
+    }
+}

--- a/hcctl/src/main.rs
+++ b/hcctl/src/main.rs
@@ -167,7 +167,7 @@ mod tests {
         let now = &Utc.ymd(2021, 1, 26).and_hms(19, 38, 0);
         let duration =
             human_readable_duration(now, &"2021-01-26T14:00:24+00:00".to_owned()).unwrap();
-        assert!(duration == "5 hour(s) and 2 minute(s) ago")
+        assert_eq!(duration, "5 hour(s) and 2 minute(s) ago")
     }
 
     #[test]
@@ -175,6 +175,6 @@ mod tests {
         let now = &Utc.ymd(2021, 1, 26).and_hms(14, 38, 0);
         let duration =
             human_readable_duration(now, &"2021-01-26T14:00:24+00:00".to_owned()).unwrap();
-        assert!(duration == "0 hour(s) and 37 minute(s) ago")
+        assert_eq!(duration, "0 hour(s) and 37 minute(s) ago")
     }
 }

--- a/hcctl/src/main.rs
+++ b/hcctl/src/main.rs
@@ -127,14 +127,7 @@ fn list(settings: Settings) -> Result<()> {
     let now = SystemTime::now();
     for check in checks {
         let date = if let Some(ref date_str) = check.last_ping {
-            let date = DateTime::parse_from_rfc3339(&date_str)?;
-            let duration = Duration::from_std(now.duration_since(SystemTime::from(date))?)?;
-            let hours = duration.num_hours();
-            format!(
-                "{} hour(s) and {} minute(s) ago",
-                hours,
-                duration.num_minutes() % if hours > 0 { hours } else { 1 }
-            )
+            human_readable_duration(&now, date_str)?
         } else {
             "-".to_owned()
         };
@@ -145,4 +138,15 @@ fn list(settings: Settings) -> Result<()> {
     table.printstd();
 
     Ok(())
+}
+
+fn human_readable_duration(now: &SystemTime, date_str: &String) -> Result<String> {
+    let date = DateTime::parse_from_rfc3339(&date_str)?;
+    let duration = Duration::from_std(now.duration_since(SystemTime::from(date))?)?;
+    let hours = duration.num_hours();
+    Ok(format!(
+        "{} hour(s) and {} minute(s) ago",
+        hours,
+        duration.num_minutes() % hours
+    ))
 }


### PR DESCRIPTION
 - Extract the parser to a separate function
 - Use UTC `DateTime` from the `chrono` crate instead of `SystemTime`
 - Handle an edge case where division by zero could occur
 - Add tests for parser