### PR TITLE
Add support for custom api urls.

### DIFF
--- a/healthchecks/src/errors.rs
+++ b/healthchecks/src/errors.rs
@@ -54,6 +54,9 @@ pub enum HealthchecksConfigError {
     /// Empty User Agent
     #[error("User Agent must not be empty")]
     EmptyUserAgent,
+	/// Empty API url
+	#[error("API url must not be empty")]
+	EmptyApiUrl,
     /// Invalid UUID
     #[error("invalid UUID: {0}")]
     InvalidUuid(String),


### PR DESCRIPTION
Healthchecks can be self-hosted, which means that we don't always need to talk to the main api url.

This PR allows us to change the api url.